### PR TITLE
Naive redis_retry_key no longer requires application code to be present

### DIFF
--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -7,10 +7,14 @@ module ResqueRetry
         helpers do
           # builds a retry key for the specified job.
           def retry_key_for_job(job)
-            klass = Resque.constantize(job['class'])
-            if klass.respond_to?(:redis_retry_key)
-              klass.redis_retry_key(job['args'])
-            else
+            begin
+              klass = Resque.constantize(job['class'])
+              if klass.respond_to?(:redis_retry_key)
+                klass.redis_retry_key(job['args'])
+              else
+                nil
+              end
+            rescue NameError
               nil
             end
           end


### PR DESCRIPTION
My initial take at removing the necessity to load the application code, which can get a bit hectic when the application is not being run under the same config.ru.

My first commit simply rescues the NameError caused by the attempt to constantize the class and return nil. This is the bare minimum to get me up and running, so it's about as much as I'm feeling comfortable to tackle without test coverage on this bit of code ;)

For an enhancement here, I suspect there could be some refactoring done to generate and return a default `redis_retry_key` when the application code is not loaded. Seems to make sense from a "sensible defaults" approach.
