### PR TITLE
  Fixes #21. MultipleWithRetrySuppression actually have general bug. 

### DIFF
--- a/lib/resque/failure/multiple_with_retry_suppression.rb
+++ b/lib/resque/failure/multiple_with_retry_suppression.rb
@@ -70,7 +70,7 @@ module Resque
       end
 
       def retry_key
-        klass.redis_retry_key(payload['args'])
+        klass.redis_retry_key(*payload['args'])
       end
 
       def failure_key

--- a/test/multiple_failure_test.rb
+++ b/test/multiple_failure_test.rb
@@ -80,6 +80,14 @@ class MultipleFailureTest < Test::Unit::TestCase
     assert_equal 5, MockFailureBackend.errors.size
   end
 
+  def test_custom_identifier_job
+    Resque.enqueue(CustomIdentifierFailingJob, 'qq', 2)
+    4.times do
+      perform_next_job(@worker)
+    end
+    assert_equal 1, MockFailureBackend.errors.size
+  end
+
   def teardown
     Resque::Failure.backend = @old_failure_backend
   end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -247,5 +247,22 @@ class InheritOrderingJobExtendLast
   end
 end
 
+
 class InheritOrderingJobExtendFirstSubclass < InheritOrderingJobExtendFirst; end
 class InheritOrderingJobExtendLastSubclass < InheritOrderingJobExtendLast; end
+
+class CustomIdentifierFailingJob
+  extend Resque::Plugins::Retry
+
+  @queue = :testing
+  @retry_limit = 2
+  @retry_delay = 0
+
+  def self.identifier(*args)
+    args.first.to_s
+  end
+
+  def self.perform(*args)
+    raise 'failed'
+  end
+end


### PR DESCRIPTION
It generated `#redis_retry_key` from array of arguments rather than arguments.

All the description in #21.
