### PR TITLE
add sleep_after_requeue feature

### DIFF
--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -89,6 +89,14 @@ module Resque
       end
 
       # @abstract
+      # Number of seconds to sleep after job is requeued
+      # 
+      # @return [Number] number of seconds to sleep
+      def sleep_after_requeue
+        @sleep_after_requeue ||= 0
+      end
+      
+      # @abstract
       # Modify the arguments used to retry the job. Use this to do something
       # other than try the exact same job again.
       #
@@ -177,7 +185,7 @@ module Resque
         retry_criteria_checks << block
       end
 
-      # Will retry the job.
+      # Retries the job.
       def try_again(*args)
         if retry_delay <= 0
           # If the delay is 0, no point passing it through the scheduler
@@ -185,6 +193,7 @@ module Resque
         else
           Resque.enqueue_in(retry_delay, self, *args_for_retry(*args))
         end
+        sleep sleep_after_requeue if sleep_after_requeue
       end
 
       # Resque before_perform hook.

--- a/test/exponential_backoff_test.rb
+++ b/test/exponential_backoff_test.rb
@@ -19,7 +19,7 @@ class ExponentialBackoffTest < Test::Unit::TestCase
 
     perform_next_job @worker
     assert_equal 1, Resque.info[:processed], '1 processed job'
-    assert_equal 1, Resque.info[:failed], 'first ever run, and it should of failed, but never retried'
+    assert_equal 1, Resque.info[:failed], 'first ever run, and it should have failed, but never retried'
     assert_equal 1, Resque.info[:pending], '1 pending job, because it never hits the scheduler'
 
     perform_next_job @worker

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -82,6 +82,22 @@ class RetryTest < Test::Unit::TestCase
     assert_equal 0, Resque.info[:pending], 'pending jobs'
   end
 
+  def test_retry_delay_sleep
+    assert_equal 0, Resque.info[:failed], 'failed jobs'
+    Resque.enqueue(SleepDelay1SecondJob)
+    before = Time.now
+    3.times do
+      perform_next_job(@worker)
+    end
+    actual_delay = Time.now - before
+    
+    assert actual_delay >= 1, "did not sleep long enough: #{actual_delay} seconds"
+    assert actual_delay < 2, "slept too long: #{actual_delay} seconds"
+    assert_equal 1, Resque.info[:failed], 'failed jobs'
+    assert_equal 2, Resque.info[:processed], 'processed job'
+    assert_equal 0, Resque.info[:pending], 'pending jobs'
+  end
+  
   def test_can_determine_if_exception_may_be_retried
     assert_equal true, RetryDefaultsJob.retry_exception?(StandardError), 'StandardError may retry'
     assert_equal true, RetryDefaultsJob.retry_exception?(CustomException), 'CustomException may retry'

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -26,6 +26,15 @@ class RetryDefaultsJob
   end
 end
 
+class SleepDelay1SecondJob < RetryDefaultsJob
+  @queue = :testing
+  @sleep_after_requeue = 1
+
+  def self.perform(*args)
+    raise if retry_attempt == 0
+  end
+end
+
 class InheritTestJob < RetryDefaultsJob
 end
 


### PR DESCRIPTION
We found it useful to have a worker sleep after re-queuing a job.  The use case is a multi-worker system in which a worker becomes broken when a request fails, but is self-healing.  We want to retry the job
immediately, but bias the request so that the broken worker does not pick it up again until it heals.

So I added an optional `sleep_after_requeue` option that does this in case it might be useful to others.

Happy to discuss if you have questions or concerns.  And thanks much for creating resque-retry: just what we needed.
