### PR TITLE
Fix #26: MultipleWithRetrySuppression swallows error if class does not ex

### DIFF
--- a/lib/resque/failure/multiple_with_retry_suppression.rb
+++ b/lib/resque/failure/multiple_with_retry_suppression.rb
@@ -79,6 +79,8 @@ module Resque
 
       def retryable?
         klass.respond_to?(:redis_retry_key)
+      rescue NameError
+        false
       end
 
       def retrying?

--- a/test/multiple_failure_test.rb
+++ b/test/multiple_failure_test.rb
@@ -26,6 +26,18 @@ class MultipleFailureTest < Test::Unit::TestCase
     assert Resque.redis.exists(key)
   end
 
+  def test_failure_is_passed_on_when_job_class_not_found
+    new_job_class = Class.new(LimitThreeJob).tap { |klass| klass.send(:instance_variable_set, :@queue, LimitThreeJob.instance_variable_get(:@queue)) }
+    Object.send(:const_set, 'LimitThreeJobTemp', new_job_class)
+    Resque.enqueue(LimitThreeJobTemp)
+
+    Object.send(:remove_const, 'LimitThreeJobTemp')
+    perform_next_job(@worker)
+
+    assert_equal MockFailureBackend.errors.count, 1
+    assert MockFailureBackend.errors.first =~ /uninitialized constant LimitThreeJobTemp/
+  end
+
   def test_last_failure_removed_from_redis_after_error_limit
     Resque.enqueue(LimitThreeJob)
     3.times do


### PR DESCRIPTION
Fix #26: MultipleWithRetrySuppression swallows error if class does not exist

Now it will simply act as Multiple and pass the NameError on up.
