### PR TITLE
Fixes #10: sets expiry (double retry delay) on keys

### DIFF
--- a/lib/resque/failure/multiple_with_retry_suppression.rb
+++ b/lib/resque/failure/multiple_with_retry_suppression.rb
@@ -19,27 +19,16 @@ module Resque
     class MultipleWithRetrySuppression < Multiple
       include Resque::Helpers
 
-      module CleanupHooks
-        # Resque after_perform hook.
-        #
-        # Deletes retry failure information from Redis.
-        def after_perform_retry_failure_cleanup(*args)
-          retry_key = redis_retry_key(*args)
-          failure_key = Resque::Failure::MultipleWithRetrySuppression.failure_key(retry_key)
-          Resque.redis.del(failure_key)
-        end
-      end
-
       # Called when the job fails.
       #
       # If the job will retry, suppress the failure from the other backends.
       # Store the lastest failure information in redis, used by the web
       # interface.
       def save
-        unless retryable? && retrying?
+        if ! (retryable? && retrying?)
           cleanup_retry_failure_log!
           super
-        else
+        elsif retry_delay > 0
           data = {
             :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S"),
             :payload   => payload,
@@ -50,12 +39,7 @@ module Resque
             :queue     => queue
           }
 
-          # Register cleanup hooks.
-          unless klass.respond_to?(:after_perform_retry_failure_cleanup)
-            klass.send(:extend, CleanupHooks)
-          end
-
-          redis[failure_key] = Resque.encode(data)
+          redis.setex(failure_key, 2*retry_delay, Resque.encode(data))
         end
       end
 
@@ -67,6 +51,10 @@ module Resque
       protected
       def klass
         constantize(payload['class'])
+      end
+
+      def retry_delay
+        klass.retry_delay
       end
 
       def retry_key

--- a/test/multiple_failure_test.rb
+++ b/test/multiple_failure_test.rb
@@ -17,41 +17,33 @@ class MultipleFailureTest < Test::Unit::TestCase
     key = "failure_" + klass.redis_retry_key(args)
   end
 
-  def test_last_failure_is_saved_in_redis
+  def test_last_failure_is_saved_in_redis_if_delay
+    Resque.enqueue(LimitThreeJobDelay1Hour)
+    perform_next_job(@worker)
+
+    # I don't like this, but...
+    key = failure_key_for(LimitThreeJobDelay1Hour)
+    assert Resque.redis.exists(key)
+  end
+
+  def test_last_failure_has_double_delay_redis_expiry_if_delay
+    Resque.enqueue(LimitThreeJobDelay1Hour)
+    perform_next_job(@worker)
+
+    # I don't like this, but...
+    key = failure_key_for(LimitThreeJobDelay1Hour)
+    assert_equal 7200, Resque.redis.ttl(key)
+  end
+
+  def test_last_failure_is_not_saved_in_redis_if_no_delay
     Resque.enqueue(LimitThreeJob)
     perform_next_job(@worker)
 
     # I don't like this, but...
     key = failure_key_for(LimitThreeJob)
-    assert Resque.redis.exists(key)
-  end
-
-  def test_last_failure_removed_from_redis_after_error_limit
-    Resque.enqueue(LimitThreeJob)
-    3.times do
-      perform_next_job(@worker)
-    end
-
-    key = failure_key_for(LimitThreeJob)
-    assert Resque.redis.exists(key)
-
-    perform_next_job(@worker)
     assert !Resque.redis.exists(key)
   end
 
-  def test_on_success_failure_log_removed_from_redis
-    SwitchToSuccessJob.successful_after = 1
-    Resque.enqueue(SwitchToSuccessJob)
-    perform_next_job(@worker)
-
-    key = failure_key_for(SwitchToSuccessJob)
-    assert Resque.redis.exists(key)
-
-    perform_next_job(@worker)
-    assert !Resque.redis.exists(key), 'key removed on success'
-  ensure
-    SwitchToSuccessJob.reset_defaults
-  end
 
   def test_errors_are_suppressed_up_to_retry_limit
     Resque.enqueue(LimitThreeJob)

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -67,6 +67,12 @@ class LimitThreeJob < RetryDefaultsJob
   end
 end
 
+class LimitThreeJobDelay1Hour < LimitThreeJob
+  @queue = :testing
+  @retry_limit = 3
+  @retry_delay = 3600
+end
+
 class FailFiveTimesJob < RetryDefaultsJob
   @queue = :testing
   @retry_limit = 6
@@ -201,32 +207,6 @@ class InheritOrderingJobExtendFirst
   def self.inherited(subclass)
     super(subclass)
     subclass.test_value = 'test'
-  end
-end
-
-# This job switches to successful after
-# n +tries+.
-class SwitchToSuccessJob < GoodJob
-  @queue = :testing
-  @max_retries = 3
-
-  class << self
-    attr_accessor :successful_after
-    attr_accessor :tries
-
-    def reset_defaults
-      self.tries = 0
-      self.successful_after = 2
-    end
-  end
-
-  reset_defaults
-
-  def self.perform(*args)
-    if self.tries < self.successful_after
-      self.tries += 1
-      raise "error"
-    end
   end
 end
 


### PR DESCRIPTION
Sets expiry (double retry delay time just to be safe) on failure keys in
MultipleWithRetrySuppression failure backend. If retry_delay is not
set, meaning we bypass the scheduler and enqueue the job again
immediately, we don't even bother writing the failure key.

This also removes the broken attempt at cleaning up these keys, which
doesn't work because the mixin never happens due to Resque's forking
model, and because the job can be run on a different box / worker
process, and because the job might not be actually run again (it could
be cleared etc.)
