### PR TITLE
Use SHA1 for default #retry_identifier

### DIFF
--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -1,3 +1,5 @@
+require 'digest/sha1'
+
 module Resque
   module Plugins
 
@@ -55,7 +57,7 @@ module Resque
       # @api public
       def retry_identifier(*args)
         args_string = args.join('-')
-        args_string.empty? ? nil : args_string
+        args_string.empty? ? nil : Digest::SHA1.hexdigest(args_string)
       end
 
       # Builds the redis key to be used for keeping state of the job

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -1,5 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
+require 'digest/sha1'
+
 class RetryTest < MiniTest::Unit::TestCase
   def setup
     Resque.redis.flushall
@@ -196,13 +198,18 @@ class RetryTest < MiniTest::Unit::TestCase
   end
 
   def test_job_without_args_has_no_ending_colon_in_redis_key
-    assert_equal 'resque-retry:GoodJob:yarrrr', GoodJob.redis_retry_key('yarrrr')
-    assert_equal 'resque-retry:GoodJob:foo', GoodJob.redis_retry_key('foo')
+    assert_equal 'resque-retry:GoodJob:' << Digest::SHA1.hexdigest('yarrrr'), GoodJob.redis_retry_key('yarrrr')
+    assert_equal 'resque-retry:GoodJob:' << Digest::SHA1.hexdigest('foo'), GoodJob.redis_retry_key('foo')
     assert_equal 'resque-retry:GoodJob', GoodJob.redis_retry_key
   end
 
-  def test_redis_retry_key_removes_whitespace
-    assert_equal 'resque-retry:GoodJob:arg1-removespace', GoodJob.redis_retry_key('arg1', 'remove space')
+  def test_redis_retry_key_removes_whitespace_for_custom_retry_identifier
+    klass = Class.new(GoodJob) do
+      def self.retry_identifier(*args)
+        args.join(' ')
+      end
+    end
+    assert_equal 'resque-retry:abc', klass.redis_retry_key('a', 'b', 'c')
   end
 
   def test_retry_delay


### PR DESCRIPTION
Myself and @pda have been having some pretty horrible problems in production with a particular job that uses large job args.  The issue stems from the fact that resque-retry encodes the entire argument list in full, which produces extremely long keys in redis.  This is actually unnecessary as a default, so this patch simply does the same thing, but passes the identifier through SHA1 before returning it.  Users can still override this default.  This should be completely backward compatible, because the key is not used for job retrieval.

Keys that used to look like (often many megabytes long):

```
resque-retry:SomeJob:something-really-longwith-spacesstripped<ahref="something">andsome</a>crazy\r\ncharacters
```

Now look like this:

```
resque-retry:SomeJob:6664635c88a68259340d77f7c6e974dede4ec026
```

In this specific example, resque is being used to defer the insertion of detailed HTTP traffic logging into the MySQL database, so the entire HTTP request headers and body need to be contained in the job arguments.
