### PR TITLE
Allow specifying exception types to be ignored

### DIFF
--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -33,6 +33,7 @@ module Resque
     #   end
     #
     module Retry
+      class AmbiguousRetryExceptionError < StandardError; end
 
       # Copy retry criteria checks on inheritance.
       #
@@ -40,6 +41,12 @@ module Resque
       def inherited(subclass)
         super(subclass)
         subclass.instance_variable_set("@retry_criteria_checks", retry_criteria_checks.dup)
+      end
+
+      def self.extended(base)
+        if base.instance_variable_get("@retry_exceptions") and base.instance_variable_get("@ignore_exceptions")
+          raise AmbiguousRetryExceptionError.new("You can't both define @retry_exceptions and @ignore_exceptions")
+        end
       end
 
       # @abstract You may override to implement a custom retry identifier,

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -168,6 +168,12 @@ class RetryTest < MiniTest::Unit::TestCase
     assert_equal 0, Resque.info[:pending], 'pending jobs'
   end
 
+  def test_dont_allow_both_retry_and_ignore_exceptions
+    assert_raises Resque::Plugins::Retry::AmbiguousRetryExceptionError do
+      AmbiguousExceptionsJob.extend(Resque::Plugins::Retry)
+    end
+  end
+
   def test_retry_failed_jobs_in_separate_queue
     Resque.enqueue(JobWithRetryQueue, 'arg1')
 

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -185,6 +185,13 @@ class RetryAllButIrrecoverableJob < RetryDefaultsJob
   end
 end
 
+class AmbiguousExceptionsJob
+  @queue = :testing
+
+  @retry_exceptions = [CustomException, HierarchyCustomException]
+  @ignore_exceptions = [TryIn3000Exception]
+end
+
 module RetryModuleDefaultsJob
   extend Resque::Plugins::Retry
   @queue = :testing


### PR DESCRIPTION
This is a convenient way to prevent certain exception types to be retried which is currently only achievable through a custom `retry_criteria_check` block.
