### PR TITLE
Match exception instance against retry_exceptions

### DIFF
--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -140,14 +140,26 @@ module Resque
         args
       end
 
-      # Convenience method to test whether you may retry on a given exception
+      # Convenience method to test whether you may retry on a given
+      # exception class
       #
       # @return [Boolean]
       #
       # @api public
-      def retry_exception?(exception)
+      def retry_exception?(exception_class)
         return true if retry_exceptions.nil?
-        !! retry_exceptions.any? { |ex| ex >= exception }
+        !! retry_exceptions.any? { |ex| ex >= exception_class }
+      end
+
+      # Convenience method to test whether you may retry on a given
+      # exception instance
+      #
+      # @return [Boolean]
+      #
+      # @api public
+      def retry_exception_instance?(exception)
+        return true if retry_exceptions.nil?
+        !! retry_exceptions.any? { |ex| ex === exception }
       end
 
       # @abstract
@@ -178,7 +190,7 @@ module Resque
         return false if retry_limit_reached?
 
         # We always want to retry if the exception matches.
-        should_retry = retry_exception?(exception.class)
+        should_retry = retry_exception_instance?(exception)
 
         # call user retry criteria check blocks.
         retry_criteria_checks.each do |criteria_check|

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -130,6 +130,17 @@ class RetryTest < MiniTest::Unit::TestCase
     assert_equal 2, Resque.info[:pending], 'pending jobs'
   end
 
+  def test_retry_if_failed_and_exception_may_retry_because_of_included_module
+    Resque.enqueue(RetryCustomExceptionsJob, 'tagged CustomException')
+    4.times do
+      perform_next_job(@worker)
+    end
+
+    assert_equal 4, Resque.info[:failed], 'failed jobs'
+    assert_equal 4, Resque.info[:processed], 'processed job'
+    assert_equal 1, Resque.info[:pending], 'pending jobs'
+  end
+
   def test_do_not_retry_if_failed_and_exception_does_not_allow_retry
     Resque.enqueue(RetryCustomExceptionsJob, AnotherCustomException)
     Resque.enqueue(RetryCustomExceptionsJob, RuntimeError)

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -1,4 +1,5 @@
 CustomException = Class.new(StandardError)
+CustomExceptionModule = Module.new
 HierarchyCustomException = Class.new(CustomException)
 AnotherCustomException = Class.new(StandardError)
 
@@ -155,12 +156,13 @@ class RetryCustomExceptionsJob < RetryDefaultsJob
   @queue = :testing
 
   @retry_limit = 5
-  @retry_exceptions = [CustomException, HierarchyCustomException]
+  @retry_exceptions = [CustomException, CustomExceptionModule, HierarchyCustomException]
 
   def self.perform(exception)
     case exception
     when 'CustomException' then raise CustomException
     when 'HierarchyCustomException' then raise HierarchyCustomException
+    when 'tagged CustomException' then raise AnotherCustomException.new.extend(CustomExceptionModule)
     when 'AnotherCustomException' then raise AnotherCustomException
     else raise StandardError
     end


### PR DESCRIPTION
This allows to 'tag' exceptions with a module instead of having to
wrap them in custom exception classes, which is useful when you want
to keep the original exception for logging and diagnosis after the
retry limit was exceeded. Using the `===` operator makes the matching
work the same as the ruby `rescue` clause.

Example:

```
module TransientError; end

def foo
  ...
rescue Timeout::Error => e
  raise e.extend(TransientError)
end

class SomeJob
  def self.retry_exceptions
    [TransientError]
  end
  ...
end
```
