### PR TITLE
Add missing "require 'resque/server'"

### DIFF
--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require 'resque/server'
 
 # Extend Resque::Server to add tabs.
 module ResqueRetry


### PR DESCRIPTION
After updating from 0.2.2 to 1.0.0a I got the following error:

```
Exception encountered: #<NameError: uninitialized constant Resque::Server>
backtrace:
/Users/manuel/.rvm/gems/ruby-1.9.3-p125@rails-3.2/gems/resque-retry-1.0.0.a/lib/resque-retry/server.rb:76:in `<top (required)>'
```

Adding `require 'resque/server'` fixed this for me.
