### PR TITLE
Match exception instance against retry_exceptions

### DIFF
--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -140,14 +140,24 @@ module Resque
         args
       end
 
-      # Convenience method to test whether you may retry on a given exception
+      # Convenience method to test whether you may retry on a given
+      # exception
+      #
+      # @param [Exception] an instance of Exception. Deprecated: can
+      # also be a Class
       #
       # @return [Boolean]
       #
       # @api public
       def retry_exception?(exception)
         return true if retry_exceptions.nil?
-        !! retry_exceptions.any? { |ex| ex >= exception }
+        !! retry_exceptions.any? do |ex|
+          if exception.is_a?(Class)
+            ex >= exception
+          else
+            ex === exception
+          end
+        end
       end
 
       # @abstract
@@ -178,7 +188,7 @@ module Resque
         return false if retry_limit_reached?
 
         # We always want to retry if the exception matches.
-        should_retry = retry_exception?(exception.class)
+        should_retry = retry_exception?(exception)
 
         # call user retry criteria check blocks.
         retry_criteria_checks.each do |criteria_check|

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -1,4 +1,5 @@
 CustomException = Class.new(StandardError)
+CustomExceptionModule = Module.new
 HierarchyCustomException = Class.new(CustomException)
 AnotherCustomException = Class.new(StandardError)
 
@@ -155,12 +156,13 @@ class RetryCustomExceptionsJob < RetryDefaultsJob
   @queue = :testing
 
   @retry_limit = 5
-  @retry_exceptions = [CustomException, HierarchyCustomException]
+  @retry_exceptions = [CustomException, CustomExceptionModule, HierarchyCustomException]
 
   def self.perform(exception)
     case exception
     when 'CustomException' then raise CustomException
     when 'HierarchyCustomException' then raise HierarchyCustomException
+    when 'tagged CustomException' then raise AnotherCustomException.new.extend(CustomExceptionModule)
     when 'AnotherCustomException' then raise AnotherCustomException
     else raise StandardError
     end


### PR DESCRIPTION
This allows to 'tag' exceptions with a module instead of having to
wrap them in custom exception classes, which is useful when you want
to keep the original exception for logging and diagnosis after the
retry limit was exceeded. Using the === operator makes the matching
work the same as the ruby rescue clause.

Example:

module TransientError; end

def foo
  ...
rescue Timeout::Error => e
  raise e.extend(TransientError)
end

class SomeJob
  def self.retry_exceptions
    [TransientError]
  end
  ...
end

The old behaviour of the public method retry_exception? so that you
can alternatively pass an exception class instead of an exception
instance to it is kept but documented as deprecated.

This is a reworked version of this commit:

https://github.com/til/resque-retry/commit/cfa397048430ed437c91abffeb4659f59d48ac15
