### PR TITLE
Adds support for introducing a degree of randomness into jobs which retry on an expontential backoff strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,18 @@ Use this if you wish to vary the delay between retry attempts:
 
                   no delay, 1m, 10m,   1h,    3h,    6h
     @backoff_strategy = [0, 60, 600, 3600, 10800, 21600]
+    @add_random_quotient = nil
+    @random_quotient_range = 3.0
 
 The first delay will be 0 seconds, the 2nd will be 60 seconds, etc...
 Again, tweak to your own needs.
 
 The number of retries is equal to the size of the `backoff_strategy`
 array, unless you set `retry_limit` yourself.
+
+If `add_random_quotient` is true, your delay values will be multiplied by a random number between
+[1.0, `random_quotient_range`]. This is useful if you have a lot of jobs fail at the same time
+(e.g., due to connectivity issues) and you don't want them all retried on the same retry schedule.
 
 ### Retry Specific Exceptions
 

--- a/lib/resque/plugins/exponential_backoff.rb
+++ b/lib/resque/plugins/exponential_backoff.rb
@@ -52,7 +52,15 @@ module Resque
       #
       # @api private
       def retry_delay
-        backoff_strategy[retry_attempt] || backoff_strategy.last
+        delay = backoff_strategy[retry_attempt] || backoff_strategy.last
+
+        # If we are adding some randomness to the delay value, multiply the value by some float between
+        # [1.0, random_quotient_range]
+        if add_random_quotient?
+          delay = (delay * (Random.rand(random_quotient_range.to_i * 10) + 10) / 10.0).to_i
+        end
+
+        delay
       end
 
       # @abstract
@@ -64,7 +72,22 @@ module Resque
       def backoff_strategy
         @backoff_strategy ||= [0, 60, 600, 3600, 10_800, 21_600]
       end
-    end
 
+      # @abstract Whether or not to add a random quotient when calculating exponential backoff. This is useful if you
+      # have multiple jobs at once that all fail at the same time (e.g., network is down) and you don't want them to all
+      # be retried at the same time.
+      # @return [Boolean] Whether or not to add a random quotient
+      def add_random_quotient?
+        @add_random_quotient
+      end
+
+      # @abstract The random quotient variability. When set to x, it means that the delay value chosen at any given
+      # time will be delay_value * Random([1.0, x]). So if you set this to 3.0, then your delay value will be multiplied
+      # by a random number between 1.0 and 3.0.
+      # @return [Float] The maximum range to be used to multiply values when adding a random quotient.
+      def random_quotient_range
+        @random_quotient_range ||= 3.0
+      end
+    end
   end
 end

--- a/test/exponential_backoff_test.rb
+++ b/test/exponential_backoff_test.rb
@@ -41,6 +41,35 @@ class ExponentialBackoffTest < MiniTest::Unit::TestCase
     assert_in_delta (start_time + 21_600),  delayed[4], 1.00, '6th delay'
   end
 
+  def test_default_backoff_strategy_with_randomness
+    start_time = Time.now.to_i
+    Resque.enqueue(ExponentialBackoffJobWithRandomness)
+
+    perform_next_job @worker
+    assert_equal 1, Resque.info[:processed],  '1 processed job'
+    assert_equal 1, Resque.info[:failed],     'first ever run, and it should have failed, but never retried'
+    assert_equal 1, Resque.info[:pending],    '1 pending job, because it never hits the scheduler'
+
+    perform_next_job @worker
+    assert_equal 2, Resque.info[:processed],  '2nd run, but first retry'
+    assert_equal 2, Resque.info[:failed],     'should of failed again, this is the first retry attempt'
+    assert_equal 0, Resque.info[:pending],    '0 pending jobs, it should be in the delayed queue'
+
+    delayed = Resque.delayed_queue_peek(0, 1)
+    assert_in_delta (start_time + 60), delayed[0], 3.00 * 60, '2nd delay' # the first had a zero delay.
+
+    5.times do
+      Resque.enqueue(ExponentialBackoffJobWithRandomness)
+      perform_next_job @worker
+    end
+
+    delayed = Resque.delayed_queue_peek(0, 5)
+    assert_in_delta (start_time + 600),     delayed[1], 3.00 * 600, '3rd delay'
+    assert_in_delta (start_time + 3600),    delayed[2], 3.00 * 3600, '4th delay'
+    assert_in_delta (start_time + 10_800),  delayed[3], 3.00 * 10_800, '5th delay'
+    assert_in_delta (start_time + 21_600),  delayed[4], 3.00 * 21_600, '6th delay'
+  end
+
   def test_custom_backoff_strategy
     start_time = Time.now.to_i
     4.times do

--- a/test/redis-test.conf
+++ b/test/redis-test.conf
@@ -106,10 +106,3 @@ databases 16
 # errors for write operations, and this may even lead to DB inconsistency.
 
 # maxmemory <bytes>
-
-############################### ADVANCED CONFIG ###############################
-
-# Glue small output buffers together in order to send small replies in a
-# single TCP packet. Uses a bit more CPU but most of the times it is a win
-# in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -135,6 +135,12 @@ class FailFiveTimesJob < RetryDefaultsJob
   end
 end
 
+class ExponentialBackoffJobWithRandomness < RetryDefaultsJob
+  extend Resque::Plugins::ExponentialBackoff
+  @queue = :testing
+  @add_random_quotient = true
+end
+
 class ExponentialBackoffJob < RetryDefaultsJob
   extend Resque::Plugins::ExponentialBackoff
   @queue = :testing


### PR DESCRIPTION
I have a few jobs where they fail in groups (e.g., they talk to an external service and that service is often down, so all X jobs running fail when this happens). Right now, all these jobs will retry at the same time.

This pull request allows you to introduce a degree of randomness into the retry schedule when using exponential backoff.
