### PR TITLE
Pass exception to args_for_retry

### DIFF
--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -42,7 +42,7 @@ module ResqueRetry
         begin
           klass = Resque.constantize(job['class'])
           if klass.respond_to?(:redis_retry_key)
-            klass.redis_retry_key(job['args'])
+            klass.redis_retry_key(*job['args'])
           else
             nil
           end

--- a/lib/resque-retry/server/views/retry.erb
+++ b/lib/resque-retry/server/views/retry.erb
@@ -12,7 +12,7 @@
 
 <table>
   <tr>
-    <th></th>
+    <th colspan=2></th>
     <th>Timestamp</th>
     <th>Job count</th>
     <th>Class</th>
@@ -28,6 +28,8 @@
         <form action="<%= u "retry/#{timestamp}/remove" %>" method="post">
           <input type="submit" value="Remove">
         </form>
+      </td>
+      <td>
         <form action="<%= u "/delayed/queue_now" %>" method="post">
           <input type="hidden" name="timestamp" value="<%= timestamp.to_i %>">
           <input type="submit" value="Queue now">

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -6,7 +6,6 @@ spec = Gem::Specification.new do |s|
   s.homepage          = 'http://github.com/lantins/resque-retry'
   s.authors           = ['Luke Antins', 'Ryan Carver']
   s.email             = 'luke@lividpenguin.com'
-  s.has_rdoc          = false
 
   s.files             = %w(LICENSE Rakefile README.md HISTORY.md)
   s.files            += Dir.glob('{bin/*,test/*,lib/**/*}')


### PR DESCRIPTION
I needed the exception class to determine what I want to put on the args. The code I added should be backwards compat with someone who implemented it the old way