### PR TITLE
fix a bug that causes the web UI to fail to display retry attempts

### DIFF
--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -42,7 +42,7 @@ module ResqueRetry
         begin
           klass = Resque.constantize(job['class'])
           if klass.respond_to?(:redis_retry_key)
-            klass.redis_retry_key(job['args'])
+            klass.redis_retry_key(*job['args'])
           else
             nil
           end


### PR DESCRIPTION
Technically this should really be `*job['args']` instead of `job['args']`. With this bug, in most case, the web UI still displays the retry attempts correctly simply because the default implementation of `retry_identifier(*args)` uses `args.join('-')` and, `['a'].join('-')` and `[['a']].join('-')` return the same string.
