### PR TITLE
Commenting out completely deprecated redis option in redis-test.conf

### DIFF
--- a/test/redis-test.conf
+++ b/test/redis-test.conf
@@ -112,4 +112,4 @@ databases 16
 # Glue small output buffers together in order to send small replies in a
 # single TCP packet. Uses a bit more CPU but most of the times it is a win
 # in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
+# glueoutputbuf yes


### PR DESCRIPTION
The glueoutputbuf option causes redis > 2.6.0 not to start & all tests to fail.
