### PR TITLE
Add after_final_failure callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,28 @@ Or you can define the entire key by overriding `redis_retry_key`.
       end
     end
 
+### After Final Failure Callbacks
+
+If you find you need to perform some logic after all the retries have failed, you can define an after final failure callback:
+
+    class WidgetProcessor
+      extend Resque::Plugins::Retry
+      @queue
+      
+      after_final_failure do |exception, widget_id|
+        mark_as_processing_failed(widget_id)
+      end
+      after_final_failure :notify_owner_of_failure
+      
+      def self.perform(widget_id)
+        heavy_lifting
+      end
+      
+      def self.notify_owner_of_failure(exception, widget_id)
+        OwnerMailer.failed_email(widget_id).send
+      end
+    end
+
 Contributing/Pull Requests
 --------------------------
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require 'timeout'
 require 'minitest/unit'
 require 'minitest/pride'
 require 'rack/test'
-require 'mocha'
+require 'mocha/mini_test'
 
 # Run code coverage in MRI 1.9 only.
 if RUBY_VERSION >= '1.9' && RUBY_ENGINE == 'ruby'

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -135,6 +135,27 @@ class FailFiveTimesJob < RetryDefaultsJob
   end
 end
 
+class FailCallbackJob < RetryDefaultsJob
+  @queue = :testing
+  @retry_limit = 3
+
+  @after_final_retry_block_called = false
+  @after_final_retry_method_called = false
+
+  after_final_failure do |exc, args|
+    @after_final_retry_block_called = true
+  end
+  after_final_failure :indicate_method_called
+
+  def self.perform(*args)
+    raise ArgumentError, "custom message"
+  end
+
+  def self.indicate_method_called(exception, *args)
+    self.instance_variable_set('@after_final_retry_method_called', true)
+  end
+end
+
 class ExponentialBackoffJob < RetryDefaultsJob
   extend Resque::Plugins::ExponentialBackoff
   @queue = :testing


### PR DESCRIPTION
This adds the ability to execute logic when the final retry has failed and won't be attempted again.
