### PR TITLE
Fix and DRY "test_helper.rb"

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,18 +48,15 @@ Resque.redis = '127.0.0.1:9736'
 # Test helpers
 class MiniTest::Unit::TestCase
   def perform_next_job(worker, &block)
-    return unless job = @worker.reserve
-    @worker.perform(job, &block)
-    @worker.done_working
+    return unless job = worker.reserve
+    worker.perform(job, &block)
+    worker.done_working
   end
 
   def clean_perform_job(klass, *args)
     Resque.redis.flushall
     Resque.enqueue(klass, *args)
-
     worker = Resque::Worker.new(:testing)
-    return false unless job = worker.reserve
-    worker.perform(job)
-    worker.done_working
+    perform_next_job(worker)
   end
 end


### PR DESCRIPTION
Minor clean-up:
- Use the passed in worker instance as opposed to the instance variable
  in "perform_next_job"
- Leverage "perform_next_job" in "clean_perform_job"
