### PR TITLE
Clean-up "resque-retry.gemspec"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ coverage/
 examples/demo/tmp
 doc/
 stdout
+tags
+tags.*
+*.gem

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,7 @@
-Copyright (c) 2010 Luke Antins
-Copyright (c) 2010 Ryan Carver
+Copyright (c) 2014 Luke Antins
+Copyright (c) 2014 Ryan Carver
+
+MIT License
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/lib/resque-retry.rb
+++ b/lib/resque-retry.rb
@@ -4,3 +4,5 @@ require 'resque_scheduler'
 require 'resque/plugins/retry'
 require 'resque/plugins/exponential_backoff'
 require 'resque/failure/multiple_with_retry_suppression'
+
+require 'resque-retry/version.rb'

--- a/lib/resque-retry/version.rb
+++ b/lib/resque-retry/version.rb
@@ -1,0 +1,3 @@
+module ResqueRetry
+  VERSION = '1.0.0'
+end

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -1,28 +1,16 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'resque-retry/version'
+
 Gem::Specification.new do |s|
-  s.name              = 'resque-retry'
-  s.version           = '1.0.0'
-  s.date              = Time.now.strftime('%Y-%m-%d')
-  s.summary           = 'A resque plugin; provides retry, delay and exponential backoff support for resque jobs.'
-  s.homepage          = 'http://github.com/lantins/resque-retry'
-  s.authors           = ['Luke Antins', 'Ryan Carver']
-  s.email             = 'luke@lividpenguin.com'
-  s.has_rdoc          = false
-
-  s.files             = %w(LICENSE Rakefile README.md HISTORY.md)
-  s.files            += Dir.glob('{bin/*,test/*,lib/**/*}')
-  s.require_paths     = ['lib']
-
-  s.add_dependency('resque', '>= 1.25.1')
-  s.add_dependency('resque-scheduler', '>= 1.9.9')
-  s.add_development_dependency('rake')
-  s.add_development_dependency('minitest', '~> 4.0')
-  s.add_development_dependency('rack-test')
-  s.add_development_dependency('yard', '~> 0.8')
-  s.add_development_dependency('json')
-  s.add_development_dependency('simplecov', '~> 0.7.1')
-  s.add_development_dependency('mocha')
-
-  s.description       = <<-EOL
+  s.name = 'resque-retry'
+  s.version = ResqueRetry::VERSION
+  s.date = Time.now.strftime('%Y-%m-%d')
+  s.authors = ['Luke Antins', 'Ryan Carver']
+  s.email = ['luke@lividpenguin.com']
+  s.summary = 'A resque plugin; provides retry, delay and exponential backoff support for resque jobs.'
+  s.description = <<-EOL
   resque-retry provides retry, delay and exponential backoff support for
   resque jobs.
 
@@ -34,4 +22,21 @@ Gem::Specification.new do |s|
   * Multiple failure backend with retry suppression & resque-web tab.
   * Small & Extendable - plenty of places to override retry logic/settings.
   EOL
+  s.homepage = 'http://github.com/lantins/resque-retry'
+  s.license = 'MIT'
+
+  s.has_rdoc = false
+  s.files = `git ls-files`.split($/)
+  s.require_paths = %w[lib]
+
+  s.add_dependency('resque', '~> 1.25')
+  s.add_dependency('resque-scheduler', '~> 1.9')
+
+  s.add_development_dependency('rake', '~> 10.1')
+  s.add_development_dependency('minitest', '~> 4.0')
+  s.add_development_dependency('rack-test', '~> 0.6')
+  s.add_development_dependency('yard', '~> 0.8')
+  s.add_development_dependency('json', '~> 1.8')
+  s.add_development_dependency('simplecov', '~> 0.7')
+  s.add_development_dependency('mocha', '~> 1.0')
 end


### PR DESCRIPTION
- Use semantic versioning for development dependencies to suppress warnings when building the gem
- Add "version.rb" per standard convention
- Add "MIT" declaration to license file and gemspec
- Add git-ignores for tag-files and locally cut gems
