### PR TITLE
Require a newer version of "resque-scheduler"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 resque-retry
 ============
 
-A [Resque][rq] plugin. Requires Resque >= 1.10.0 & [resque-scheduler][rqs] >= 1.9.9.
+A [Resque][rq] plugin. Requires Resque ~> 1.25 & [resque-scheduler][rqs] ~> 2.5.
 
 resque-retry provides retry, delay and exponential backoff support for
 resque jobs.

--- a/lib/resque-retry/version.rb
+++ b/lib/resque-retry/version.rb
@@ -1,3 +1,3 @@
 module ResqueRetry
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency('resque', '~> 1.25')
-  s.add_dependency('resque-scheduler', '~> 1.9')
+  s.add_dependency('resque-scheduler', '~> 2.5')
 
   s.add_development_dependency('rake', '~> 10.1')
   s.add_development_dependency('minitest', '~> 4.0')


### PR DESCRIPTION
- In an attempt to not get too far behind, bump the "resque-scheduler"
  version to "~> 2.5"

This ensures that the dependencies on scheduler are up to date. I would suggest, if you see fit, merging this, cutting the "1.1.1" gem and yanking version "1.1.0" (its dependencies were too restrictive).
