### PR TITLE
Allow specification of "@fatal_exceptions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,26 @@ In the above example, Resque would retry any `DeliverSMS` jobs which throw a
 will be retried 30 seconds later, if it throws `SystemCallError` it will first
 retry 120 seconds later then subsequent retry attempts 240 seconds later.
 
+### Fail Fast For Specific Exceptions
+
+The default will allow a retry for any type of exception. You may change
+it so specific exceptions fail immediately by using `fatal_exceptions`:
+
+    class DeliverSMS
+      extend Resque::Plugins::Retry
+      @queue = :mt_divisions
+
+      @fatal_exceptions = [NetworkError]
+
+      def self.perform(mt_id, mobile_number, message)
+        heavy_lifting
+      end
+    end
+
+In the above example, Resque would retry any `DeliverSMS` jobs that throw any
+type of error other than `NetworkError`. If the job throws a `NetworkError` it
+will be marked as "failed" immediately.
+
 ### Custom Retry Criteria Check Callbacks
 
 You may define custom retry criteria callbacks:

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -169,6 +169,35 @@ class RetryCustomExceptionsJob < RetryDefaultsJob
   end
 end
 
+class AmbiguousRetryStrategyJob
+  @queue = :testing
+
+  @fatal_exceptions = [CustomException]
+  @retry_exceptions = [AnotherCustomException]
+end
+
+class FailOnCustomExceptionJob
+  extend Resque::Plugins::Retry
+  @queue = :testing
+
+  @fatal_exceptions = [CustomException]
+
+  def self.perform(*args)
+    raise CustomException
+  end
+end
+
+class FailOnCustomExceptionButRaiseStandardErrorJob
+  extend Resque::Plugins::Retry
+  @queue = :testing
+
+  @fatal_exceptions = [CustomException]
+
+  def self.perform(*args)
+    raise StandardError
+  end
+end
+
 module RetryModuleDefaultsJob
   extend Resque::Plugins::Retry
   @queue = :testing


### PR DESCRIPTION
When a fatal exception is raised the job will be immediately marked as
"failed" (this is the inverse of "@retry_exceptions").

High level changes:
- Ensure that only one of the two exception handling stategies is
  specified (e.g. "@fatal_exceptions" or "@retry_exceptions")
- Favor checking "retry_exceptions" over "fatal_exceptions" as it has
  been part of the API for a longer time
- Add tests to cover the validation and feature behavior
- Update documentation
