### PR TITLE
Introduce a little randomness into "retry_delay"

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,12 +208,21 @@ Use this if you wish to vary the delay between retry attempts:
 
                   no delay, 1m, 10m,   1h,    3h,    6h
     @backoff_strategy = [0, 60, 600, 3600, 10800, 21600]
+    @retry_delay_multiplicand_min = 1.0
+    @retry_delay_multiplicand_max = 1.0
 
 The first delay will be 0 seconds, the 2nd will be 60 seconds, etc...
 Again, tweak to your own needs.
 
 The number of retries is equal to the size of the `backoff_strategy`
 array, unless you set `retry_limit` yourself.
+
+The delay values will be multiplied by a random `Float` value between
+`retry_delay_multiplicand_min` and `retry_delay_multiplicand_max` (both have a
+default of `1.0`). The product (`delay_multiplicand`) is recalculated on every
+attempt. This feature can be useful if you have a lot of jobs fail at the same
+time (e.g. rate-limiting/throttling or connectivity issues) and you don't want
+them all retried on the same schedule.
 
 ### Retry Specific Exceptions
 

--- a/lib/resque/plugins/exponential_backoff.rb
+++ b/lib/resque/plugins/exponential_backoff.rb
@@ -52,7 +52,32 @@ module Resque
       #
       # @api private
       def retry_delay
-        backoff_strategy[retry_attempt] || backoff_strategy.last
+        delay = backoff_strategy[retry_attempt] || backoff_strategy.last
+        delay_multiplicand = \
+          rand(retry_delay_multiplicand_min..retry_delay_multiplicand_max)
+        (delay * delay_multiplicand).to_i
+      end
+
+      # @abstract
+      # The minimum value (lower-bound) for the range that is is used in
+      # calculating the retry-delay product
+      #
+      # @return [Float]
+      #
+      # @api public
+      def retry_delay_multiplicand_min
+        @retry_delay_multiplicand_min ||= 1.0
+      end
+
+      # @abstract
+      # The maximum value (upper-bound) for the range that is is used in
+      # calculating the retry-delay product
+      #
+      # @return [Float]
+      #
+      # @api public
+      def retry_delay_multiplicand_max
+        @retry_delay_multiplicand_max ||= 1.0
       end
 
       # @abstract

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -140,6 +140,25 @@ class ExponentialBackoffJob < RetryDefaultsJob
   @queue = :testing
 end
 
+class ExponentialBackoffWithRetryDelayMultiplicandMinJob < RetryDefaultsJob
+  extend Resque::Plugins::ExponentialBackoff
+  @queue = :testing
+  @retry_delay_multiplicand_min = 0.5
+end
+
+class ExponentialBackoffWithRetryDelayMultiplicandMaxJob < RetryDefaultsJob
+  extend Resque::Plugins::ExponentialBackoff
+  @queue = :testing
+  @retry_delay_multiplicand_max = 3.0
+end
+
+class ExponentialBackoffWithRetryDelayMultiplicandMinAndMaxJob < RetryDefaultsJob
+  extend Resque::Plugins::ExponentialBackoff
+  @queue = :testing
+  @retry_delay_multiplicand_min = 0.5
+  @retry_delay_multiplicand_max = 3.0
+end
+
 class CustomExponentialBackoffJob
   extend Resque::Plugins::ExponentialBackoff
   @queue = :testing


### PR DESCRIPTION
Add the ability to specify either "retry_delay_multiplicand_min" or
"retry_delay_multiplicand_max" or both. These values will be used by
the "ExponentialBackoff" retry-strategy. By tuning these values you
can stagger retry attempts in situations where a large number of jobs
fail around the same time (e.g. rate-limiting/throttling or connectivity
issues).
