### PR TITLE
Validations for multiplicand min/max configuration

### DIFF
--- a/test/exponential_backoff_test.rb
+++ b/test/exponential_backoff_test.rb
@@ -41,6 +41,20 @@ class ExponentialBackoffTest < MiniTest::Unit::TestCase
     assert_in_delta (start_time + 21_600),  delayed[4], 1.00, '6th delay'
   end
 
+  def test_dont_allow_both_retry_and_ignore_exceptions
+    job_types = [
+      InvalidRetryDelayMaxConfigurationJob,
+      InvalidRetryDelayMinAndMaxConfigurationJob,
+      InvalidRetryDelayMinConfigurationJob,
+    ]
+
+    job_types.each do |job_type|
+      assert_raises Resque::Plugins::ExponentialBackoff::InvalidRetryDelayMultiplicandConfigurationException do
+        job_type.extend(Resque::Plugins::ExponentialBackoff)
+      end
+    end
+  end
+
   def test_default_backoff_strategy_with_retry_delay_multiplicands
     job_types = [
       ExponentialBackoffWithRetryDelayMultiplicandMaxJob,

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -159,6 +159,22 @@ class ExponentialBackoffWithRetryDelayMultiplicandMinAndMaxJob < RetryDefaultsJo
   @retry_delay_multiplicand_max = 3.0
 end
 
+class InvalidRetryDelayMaxConfigurationJob
+  @queue = :testing
+  @retry_delay_multiplicand_max = 0.9
+end
+
+class InvalidRetryDelayMinConfigurationJob
+  @queue = :testing
+  @retry_delay_multiplicand_min = 1.1
+end
+
+class InvalidRetryDelayMinAndMaxConfigurationJob
+  @queue = :testing
+  @retry_delay_multiplicand_min = 3.0
+  @retry_delay_multiplicand_max = 0.5
+end
+
 class CustomExponentialBackoffJob
   extend Resque::Plugins::ExponentialBackoff
   @queue = :testing


### PR DESCRIPTION
Ensure that "retry_delay_multiplicand_min" is less than or equal to
"retry_delay_multiplicand_max" (this applies to cases where both values
are specified or if only one or the other is specified and it conflicts
with the other multiplicand's default value)
