### PR TITLE
allow setting the expire_retry_key_after value on the fly

### DIFF
--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -148,6 +148,16 @@ module Resque
       end
 
       # @abstract
+      # The number of seconds to set the TTL to on the resque-retry key in redis
+      # 
+      # @return [Number] number of seconds
+      #
+      # @api public
+      def expire_retry_key_after
+        @expire_retry_key_after
+      end
+
+      # @abstract
       # Modify the arguments used to retry the job. Use this to do something
       # other than try the exact same job again
       #
@@ -350,7 +360,7 @@ module Resque
         Resque.redis.setnx(retry_key, -1)             # default to -1 if not set.
         @retry_attempt = Resque.redis.incr(retry_key) # increment by 1.
         log_message "attempt: #{@retry_attempt} set in Redis", args
-        Resque.redis.expire(retry_key, @retry_delay.to_i + @expire_retry_key_after.to_i) if @expire_retry_key_after
+        Resque.redis.expire(retry_key, @retry_delay.to_i + expire_retry_key_after.to_i) if expire_retry_key_after
       end
 
       # Resque after_perform hook

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -285,4 +285,17 @@ class RetryTest < MiniTest::Unit::TestCase
     Resque.enqueue(ExpiringJob, 'expiry_test')
     perform_next_job(@worker)
   end
+
+  def test_expire_key_setting_on_the_fly
+    Resque.redis.expects(:expire).with("resque-retry:FailFiveTimesWithCustomExpiryJob", 100)
+    .then.with("resque-retry:FailFiveTimesWithCustomExpiryJob", 101)
+    .then.with("resque-retry:FailFiveTimesWithCustomExpiryJob", 102)
+    .then.with("resque-retry:FailFiveTimesWithCustomExpiryJob", 103)
+    .then.with("resque-retry:FailFiveTimesWithCustomExpiryJob", 104)
+
+    Resque.enqueue(FailFiveTimesWithCustomExpiryJob)
+    5.times do
+      perform_next_job(@worker)
+    end
+  end
 end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -154,6 +154,19 @@ class FailFiveTimesWithExpiryJob < RetryDefaultsJob
   end
 end
 
+class FailFiveTimesWithCustomExpiryJob < RetryDefaultsJob
+  @queue = :testing
+  @retry_limit = 6
+
+  def self.expire_retry_key_after
+    retry_attempt + 100
+  end
+
+  def self.perform(*args)
+    raise if retry_attempt <= 4
+  end
+end
+
 class ExponentialBackoffJob < RetryDefaultsJob
   extend Resque::Plugins::ExponentialBackoff
   @queue = :testing


### PR DESCRIPTION
hey @lantins, @jzaleski

I found an issue in how we handle the expire retry key after value. The problem is that if you have a backoff period where some of the backoff values are larger than whatever default value you set your expiry to, you can end up in a situation where your job will lose its retry key from redis before it gets to retry.

My initial solution was to simply make sure that expire_retry_key_after is always set to backoff_strategy.sum + 1.hour in our implementation, like this:

```
@backoff_strategy = [1.minutes, 1.hour, 1.day]
@expire_retry_key_after = @backoff_strategy.sum + 1.hour
```

The problem with this is that somebody who doesnt know the internals can come along and create a job where they set the backoff strategy to something custom but never update the expire_retry_key_after value. So I decided it would make sense for expire_retry_key_after to be boxed into a function that I can just override in my template like this:

```
def expire_retry_key_after
  backoff_strategy.sum + 1.hour
end
```

thoughts?

cc @camilo
