### PR TITLE
Upgrade "resque-scheduler" to "3.0.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 resque-retry
 ============
 
-A [Resque][rq] plugin. Requires Resque ~> 1.25 & [resque-scheduler][rqs] ~> 2.5.
+A [Resque][rq] plugin. Requires Resque ~> 1.25 & [resque-scheduler][rqs] ~> 3.0.
 
 resque-retry provides retry, delay and exponential backoff support for
 resque jobs.
@@ -28,7 +28,7 @@ If you're using [Bundler][bundler] to manage your dependencies, you should add `
 Add this to your `Rakefile`:
 ```ruby
 require 'resque/tasks'
-require 'resque_scheduler/tasks'
+require 'resque/scheduler/tasks'
 ```
 
 The delay between retry attempts is provided by [resque-scheduler][rqs].

--- a/examples/demo/Rakefile
+++ b/examples/demo/Rakefile
@@ -12,7 +12,7 @@ require 'resque/failure/redis'
 
 # Require Rakefile related resque things.
 require 'resque/tasks'
-require 'resque_scheduler/tasks'
+require 'resque/scheduler/tasks'
 
 # Enable resque-retry failure backend.
 Resque::Failure::MultipleWithRetrySuppression.classes = [Resque::Failure::Redis]

--- a/lib/resque-retry.rb
+++ b/lib/resque-retry.rb
@@ -1,5 +1,5 @@
 require 'resque'
-require 'resque_scheduler'
+require 'resque-scheduler'
 
 require 'resque/plugins/retry'
 require 'resque/plugins/exponential_backoff'

--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -1,6 +1,6 @@
 require 'cgi'
 require 'resque/server'
-require 'resque_scheduler/server'
+require 'resque/scheduler/server'
 
 # Extend Resque::Server to add tabs.
 module ResqueRetry

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency('resque', '~> 1.25')
-  s.add_dependency('resque-scheduler', '~> 2.5')
+  s.add_dependency('resque-scheduler', '~> 3.0')
 
   s.add_development_dependency('rake', '~> 10.1')
   s.add_development_dependency('minitest', '~> 4.0')


### PR DESCRIPTION
- Upgrade "resque-scheduler" gem
- Reference "resque/scheduler/tasks" instead of "resque_scheduler/tasks"
- Update "README.md" to reflect new requirement

_with this change all dependencies will be up-to-date_
