### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ resque-retry
 ============
 
 A [Resque][rq] plugin. Requires Resque ~> 1.25 & [resque-scheduler][rqs] ~> 3.0.
-
+pat
 resque-retry provides retry, delay and exponential backoff support for
 resque jobs.
 
@@ -120,7 +120,7 @@ require 'resque-retry'
 require 'resque-retry/server'
 
 # Make sure to require your workers & application code below this line:
-# require '[path]/[to]/[jobs]/your_worker.rb' 
+# require '[path]/[to]/[jobs]/your_worker' 
 
 # Run the server
 run Resque::Server.new
@@ -153,7 +153,7 @@ require 'resque-retry'
 require 'resque-retry/server'
 
 # Make sure to require your workers & application code below this line:
-# require '[path]/[to]/[jobs]/your_worker.rb' 
+# require '[path]/[to]/[jobs]/your_worker' 
 
 ```
 


### PR DESCRIPTION
Improved README.md to explain the steps needed to start the 'resque-web' server interface properly with the 'resque-retry' features. 

The problems as I identified them essentially were: 
A. The README proposed a rack configuration, but didn't include an example command for a user to start the server. Solution: Added a simple example on how to start the server with bundler by loading the proposed rack configuration. 
B. The README didn't include the alternate option of starting the resque-web interface using the built-in 'resque-web' command. Solution: Included a simple 3 step explanation on how to use the resque-web command by sending it a configuration file as a parameter
