### PR TITLE
Added exception_notification gem to README for Resque::Failure::Multi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ require 'resque/failure/redis'
 
 Resque::Failure::MultipleWithRetrySuppression.classes = [Resque::Failure::Redis]
 Resque::Failure.backend = Resque::Failure::MultipleWithRetrySuppression
+
+# if you are using the exception_notification gem and want to be notified about the last failed retry be sure to include the ExceptionNotification::Resque failure backend
+Resque::Failure::MultipleWithRetrySuppression.classes = [Resque::Failure::Redis, ExceptionNotification::Resque]
+Resque::Failure.backend = Resque::Failure::MultipleWithRetrySuppression
 ```
 
 If a job fails, but **can and will** retry, the failure details wont be


### PR DESCRIPTION
See my confusing issue: https://github.com/lantins/resque-retry/issues/120
Exception notifications only work, when ExceptionNotification::Resque failure backend is explicit defined for the use with Resque::Failure::MultipleWithRetrySuppression.

```
Resque::Failure::MultipleWithRetrySuppression.classes = [Resque::Failure::Redis, ExceptionNotification::Resque]
Resque::Failure.backend = Resque::Failure::MultipleWithRetrySuppression
```