### PR TITLE
Add ability to 'ignore' certain exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Here are a list of the options provided (click to jump):
  * [Job Retry Identifier/Key](#retry_key)
  * [Expire Retry Counters From Redis](#expire)
  * [Try Again and Give Up Callbacks](#callbacks)
+ * [Ignored Exceptions](#ignored)
  * [Debug Plugin Logging](#debug_log)
 
 ### <a name="retry_defaults"></a> Retry Defaults 
@@ -557,6 +558,25 @@ end
 Warning: Make sure your callbacks do not throw any exceptions. If they do,
 subsequent callbacks will not be triggered, and the job will not be retried
 (if it was trying again). The retry counter also will not be reset.
+
+### <a name="ignored"></a> Ignored Exceptions
+If there is an exception for which you want to retry, but you don't want it to
+increment your retry counter, you can add it to `@ignore_exceptions`.
+
+One use case: Restarting your workers triggers a `Resque::TermException`. You
+may want your workers to retry the job that they were working on, but without
+incrementing the retry counter.
+
+```ruby
+class RestartResilientJob
+  extend Resque::Plugins::Retry
+
+  @retry_exceptions = [Resque::TermException]
+  @ignore_exceptions = [Resque::TermException]
+end
+```
+
+Reminder: `@ignore_exceptions` should be a subset of `@retry_exceptions`.
 
 ### <a name="debug_log"></a> Debug Plugin Logging
 

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ return true.
 
 You can also register a retry criteria check with a Symbol if the method is
 already defined on the job class:
-```
+```ruby
 class AlwaysRetryJob
   extend Resque::Plugins::Retry
 
@@ -397,6 +397,7 @@ class AlwaysRetryJob
     true
   end
 end
+```
 
 Use `@retry_exceptions = []` to **only** use your custom retry criteria checks
 to determine if the job should retry.

--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -453,6 +453,13 @@ module Resque
           return
         end
 
+        # If we are "ignoring" the exception, then we decrement the retry
+        # counter, so that the current attempt didn't count toward the retry
+        # counter.
+        if !@ignore_exceptions.nil? && @ignore_exceptions.include?(exception.class)
+          Resque.redis.decr(redis_retry_key(*args))
+        end
+
         if retry_criteria_valid?(exception, *args)
           try_again(exception, *args)
         else

--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -456,8 +456,8 @@ module Resque
         # If we are "ignoring" the exception, then we decrement the retry
         # counter, so that the current attempt didn't count toward the retry
         # counter.
-        if !@ignore_exceptions.nil? && @ignore_exceptions.include?(exception.class)
-          Resque.redis.decr(redis_retry_key(*args))
+        if ignore_exceptions.include?(exception.class)
+          @retry_attempt = Resque.redis.decr(redis_retry_key(*args))
         end
 
         if retry_criteria_valid?(exception, *args)
@@ -589,6 +589,10 @@ module Resque
         give_up_callbacks.each do |callback|
           call_symbol_or_block(callback, exception, *args)
         end
+      end
+
+      def ignore_exceptions
+        @ignore_exceptions ||= []
       end
 
       # Helper to call functions that may be passed as Symbols or Procs. If

--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -52,18 +52,22 @@ module Resque
       #
       # @api private
       def self.extended(receiver)
-        if receiver.instance_variable_get('@fatal_exceptions') && receiver.instance_variable_get('@retry_exceptions')
+        retry_exceptions = receiver.instance_variable_get('@retry_exceptions')
+        fatal_exceptions = receiver.instance_variable_get('@fatal_exceptions')
+        ignore_exceptions = receiver.instance_variable_get('@ignore_exceptions')
+
+        if fatal_exceptions && retry_exceptions
           raise AmbiguousRetryStrategyException.new(%{You can't define both "@fatal_exceptions" and "@retry_exceptions"})
         end
 
         # Check that ignore_exceptions is a subset of retry_exceptions
-        retry_exceptions = receiver.instance_variable_get('@retry_exceptions')
         if retry_exceptions.is_a?(Hash)
           exceptions = retry_exceptions.keys
         else
           exceptions = Array(retry_exceptions)
         end
-        excess_exceptions = Array(receiver.instance_variable_get('@ignore_exceptions')) - exceptions
+
+        excess_exceptions = Array(ignore_exceptions) - exceptions
         unless excess_exceptions.empty?
           raise RetryConfigurationException, "The following exceptions are defined in @ignore_exceptions but not in @retry_exceptions: #{excess_exceptions.join(', ')}."
         end

--- a/test/ignore_exceptions_test.rb
+++ b/test/ignore_exceptions_test.rb
@@ -23,4 +23,16 @@ class IgnoreExceptionsTest < Minitest::Test
     perform_next_job(@worker)
     assert_equal '1', Resque.redis.get(retry_key), 'retry counter'
   end
+
+  def test_ignore_exception_configuration_1
+    assert_raises Resque::Plugins::Retry::RetryConfigurationException do
+      IgnoreExceptionsImproperlyConfiguredJob1.extend(Resque::Plugins::Retry)
+    end
+  end
+
+  def test_ignore_exception_configuration_2
+    assert_raises Resque::Plugins::Retry::RetryConfigurationException do
+      IgnoreExceptionsImproperlyConfiguredJob2.extend(Resque::Plugins::Retry)
+    end
+  end
 end

--- a/test/ignore_exceptions_test.rb
+++ b/test/ignore_exceptions_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class IgnoreExceptionsTest < Minitest::Test
+  def setup
+    Resque.redis.flushall
+    @worker = Resque::Worker.new(:testing)
+    @worker.register_worker
+  end
+
+  def test_ignore_exceptions
+    Resque.enqueue(IgnoreExceptionsJob)
+    retry_key = IgnoreExceptionsJob.redis_retry_key
+
+    IgnoreExceptionsJob.stubs(:perform).raises(AnotherCustomException)
+    perform_next_job(@worker)
+    assert_equal '0', Resque.redis.get(retry_key), 'retry counter'
+
+    IgnoreExceptionsJob.stubs(:perform).raises(AnotherCustomException)
+    perform_next_job(@worker)
+    assert_equal '1', Resque.redis.get(retry_key), 'retry counter'
+
+    IgnoreExceptionsJob.stubs(:perform).raises(CustomException)
+    perform_next_job(@worker)
+    assert_equal '1', Resque.redis.get(retry_key), 'retry counter'
+  end
+end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -579,3 +579,15 @@ class RetryCallbacksJob
 
   give_up_callback :on_give_up_c
 end
+
+class IgnoreExceptionsJob
+  extend Resque::Plugins::Retry
+  @queue = :testing
+  @ignore_exceptions = [CustomException]
+  @retry_exceptions = [CustomException, AnotherCustomException]
+  @retry_limit = 3
+
+  def self.perform
+    "Hello, World!"
+  end
+end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -591,3 +591,16 @@ class IgnoreExceptionsJob
     "Hello, World!"
   end
 end
+
+class IgnoreExceptionsImproperlyConfiguredJob1
+  # Manually extend Resque::Plugins::Retry in the test code to catch the
+  # exception.
+  @ignore_exceptions = [CustomException]
+end
+
+class IgnoreExceptionsImproperlyConfiguredJob2
+  # Manually extend Resque::Plugins::Retry in the test code to catch the
+  # exception.
+  @ignore_exceptions = [CustomException]
+  @retry_exceptions = { AnotherCustomException => 0 }
+end


### PR DESCRIPTION
I needed this feature for my job -- in particular, I didn't want `Resque::TermException` to increment the retry counter, since that exception gets triggered whenever we deploy (during which we restart our worker processes).

The naming might not be the best, the functionality is what we want for my work. I'm opening the PR here in case you want to merge this into the project.