### PR TITLE
do not crash if job class is not found on the resque-web server

### DIFF
--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -40,7 +40,7 @@ module ResqueRetry
       # builds a retry key for the specified job.
       def retry_key_for_job(job)
         klass = get_class(job)
-        if klass && klass.respond_to?(:redis_retry_key)
+        if klass.respond_to?(:redis_retry_key)
           klass.redis_retry_key(job['args'])
         else
           nil


### PR DESCRIPTION
closes https://github.com/lantins/resque-retry/issues/130
