### PR TITLE
Superclass delay

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ## HEAD
 
+* Feature: If no exact exception class is present in `@retry_exceptions` hash, try to find closest superclass (@fanfilmu)
 * Feature: When running Resque inline, explicitly don't try to retry, don't touch Redis (@michaelglass)
 
 # 1.5.0 (2015-10-24)

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -286,9 +286,12 @@ class RetryTest < Minitest::Test
 
   def test_retry_delay
     assert_equal 3, NormalRetryCountJob.retry_delay
-    assert_equal 7, PerExceptionClassRetryCountJob.retry_delay(RuntimeError)
-    assert_equal 11, PerExceptionClassRetryCountJob.retry_delay(Exception)
-    assert_equal 13, PerExceptionClassRetryCountJob.retry_delay(Timeout::Error)
+    assert_equal 7, PerExceptionClassRetryCountJob.retry_delay(StandardError)
+    assert_equal 7, PerExceptionClassRetryCountJob.retry_delay(CustomException)
+    assert_equal 11, PerExceptionClassRetryCountJob.retry_delay(AnotherCustomException)
+    assert_equal 13, PerExceptionClassRetryCountJob.retry_delay(HierarchyCustomException)
+
+    assert_equal 7, PerExceptionClassRetryCountJob.instance_variable_get("@retry_exceptions")[CustomException]
   end
 
   def test_expire_key_set

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -496,7 +496,7 @@ class PerExceptionClassRetryCountJob
 
   @queue = :testing
   @retry_limit = 3
-  @retry_exceptions = { RuntimeError => 7, Exception => 11, Timeout::Error => 13 }
+  @retry_exceptions = { StandardError => 7, AnotherCustomException => 11, HierarchyCustomException => 13 }
 
   def self.perform
     raise RuntimeError, 'I always fail with a RuntimeError'


### PR DESCRIPTION
I've noticed that when Resque::Retry checks whether or not exception should be retried, it allows thrown exception to be a subclass of any exception from `@retry_exceptions` ([here](https://github.com/lantins/resque-retry/blob/f7088a3d9110f2bffb3899ac872cd6ee6f528961/lib/resque/plugins/retry.rb#L228)), but when fetching delay for such exception, it is required to supply exact exception class ([here](https://github.com/lantins/resque-retry/blob/f7088a3d9110f2bffb3899ac872cd6ee6f528961/lib/resque/plugins/retry.rb#L145)).

This PR changes behaviour so that the closest superclass (or exact exception class, if present `@retry_exceptions`) is used to fetch delay for thrown exception on retry.

I will appreciate any suggestions! :)
