### PR TITLE
Customize queue and retry time on job arguments

### DIFF
--- a/test/retry_custom_delay_test.rb
+++ b/test/retry_custom_delay_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class RetryCustomDelayTest < Minitest::Test
+  def setup
+    Resque.redis.flushall
+    @worker = Resque::Worker.new(:testing)
+    @worker.register_worker
+  end
+
+  def test_delay_with_exception
+    Resque.enqueue(DynamicDelayedJobOnException, 'arg1')
+    Resque.expects(:enqueue_in_with_queue).with(:testing, 4, DynamicDelayedJobOnException, 'arg1')
+
+    perform_next_job(@worker)
+  end
+
+  def test_delay_with_exception_and_args
+    Resque.enqueue(DynamicDelayedJobOnExceptionAndArgs, '3')
+    Resque.expects(:enqueue_in_with_queue).with(:testing, 3, DynamicDelayedJobOnExceptionAndArgs, '3')
+
+    perform_next_job(@worker)
+  end
+end

--- a/test/retry_queue_test.rb
+++ b/test/retry_queue_test.rb
@@ -13,4 +13,13 @@ class RetryQueueTest < Minitest::Test
 
     perform_next_job(@worker)
   end
+
+  def test_retry_delayed_failed_jobs_in_dynamic_queue
+    queue_name = "dynamic_queue_#{Time.now.to_i}"
+
+    Resque.enqueue(JobWithDynamicRetryQueue, queue_name)
+    Resque.expects(:enqueue_in_with_queue).with(queue_name, 1, JobWithDynamicRetryQueue, queue_name)
+
+    perform_next_job(@worker)
+  end
 end

--- a/test/retry_queue_test.rb
+++ b/test/retry_queue_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class RetryQueueTest < Minitest::Test
+  def setup
+    Resque.redis.flushall
+    @worker = Resque::Worker.new(:testing)
+    @worker.register_worker
+  end
+
+  def test_retry_delayed_failed_jobs_in_separate_queue
+    Resque.enqueue(DelayedJobWithRetryQueue, 'arg1')
+    Resque.expects(:enqueue_in_with_queue).with(:testing_retry_delegate, 1, JobRetryQueue, 'arg1')
+
+    perform_next_job(@worker)
+  end
+end

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -221,7 +221,7 @@ class RetryTest < Minitest::Test
 
     perform_next_job(@worker)
 
-    assert job_from_retry_queue = Resque.pop(:testing_retry)
+    assert job_from_retry_queue = Resque.pop(:testing_retry_delegate)
     assert_equal ['arg1'], job_from_retry_queue['args']
     assert_nil Resque.redis.get(JobWithRetryQueue.redis_retry_key('arg1'))
   end
@@ -236,7 +236,7 @@ class RetryTest < Minitest::Test
 
   def test_retry_delayed_failed_jobs_in_separate_queue
     Resque.enqueue(DelayedJobWithRetryQueue, 'arg1')
-    Resque.expects(:enqueue_in).with(1, JobRetryQueue, 'arg1')
+    Resque.expects(:enqueue_in_with_queue).with(:testing_retry_delegate, 1, JobRetryQueue, 'arg1')
 
     perform_next_job(@worker)
   end

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -234,13 +234,6 @@ class RetryTest < Minitest::Test
     perform_next_job(@worker)
   end
 
-  def test_retry_delayed_failed_jobs_in_separate_queue
-    Resque.enqueue(DelayedJobWithRetryQueue, 'arg1')
-    Resque.expects(:enqueue_in_with_queue).with(:testing_retry_delegate, 1, JobRetryQueue, 'arg1')
-
-    perform_next_job(@worker)
-  end
-
   def test_delete_redis_key_when_job_is_successful
     Resque.enqueue(GoodJob, 'arg1')
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,13 +2,6 @@ dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift dir + '/../lib'
 $TESTING = true
 
-require 'rubygems'
-require 'timeout'
-require 'minitest/autorun'
-require 'minitest/pride'
-require 'rack/test'
-require 'mocha/setup'
-
 # Run code coverage in MRI 1.9 only.
 if RUBY_VERSION >= '1.9' && RUBY_ENGINE == 'ruby'
   require 'simplecov'
@@ -16,6 +9,13 @@ if RUBY_VERSION >= '1.9' && RUBY_ENGINE == 'ruby'
     add_filter '/test/'
   end
 end
+
+require 'rubygems'
+require 'timeout'
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'rack/test'
+require 'mocha/setup'
 
 require 'resque-retry'
 require dir + '/test_jobs'

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -72,6 +72,20 @@ class JobWithRetryQueue
   end
 end
 
+class JobWithDynamicRetryQueue
+  extend Resque::Plugins::Retry
+  @queue = :testing
+  @retry_delay = 1
+
+  def self.retry_queue(exception, *args)
+    args.first
+  end
+
+  def self.perform(*args)
+    raise
+  end
+end
+
 class DelayedJobWithRetryQueue
   extend Resque::Plugins::Retry
   @queue = :testing

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -86,6 +86,36 @@ class JobWithDynamicRetryQueue
   end
 end
 
+class DynamicDelayedJobOnExceptionAndArgs
+  extend Resque::Plugins::Retry
+  @queue = :testing
+
+  def self.retry_delay(exception, *args)
+    args.first.to_i
+  end
+
+  def self.perform(*args)
+    raise
+  end
+end
+
+class DynamicDelayedJobOnException
+  extend Resque::Plugins::Retry
+  @queue = :testing
+
+  def self.retry_delay(exception)
+    if exception == SocketError
+      4
+    else
+      1
+    end
+  end
+
+  def self.perform(*args)
+    raise SocketError
+  end
+end
+
 class DelayedJobWithRetryQueue
   extend Resque::Plugins::Retry
   @queue = :testing

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -56,7 +56,7 @@ end
 
 class JobRetryQueue
   extend Resque::Plugins::Retry
-  @queue = :testing_retry
+  @queue = :testing_retry_delegate
 
   def self.perform(*args)
   end


### PR DESCRIPTION
Thank you for all of the hard work on this resque extension!

As my queue size and user base has grown I've had the need to:

- Change the retry time based on custom logic. Specifically, how many jobs are queued up for a specific user. Right now, retry time can be only be customized based on the exception. I need to retry it based on the specific user that is being processed which is passed in with the job args.

- Change the queue that a job is retried to based on custom logic. In my scenario there are specific types of errors from an application I integrate that do not need to be retried with the same level of priority. There are also cases where specific type of jobs should be moved to a low priority queue if they fail the first time. 

The larger issue that this allow users to solve is customizing their queue logic so it works well in a multi-tenant environment (ex: https://stackoverflow.com/questions/33708349/multi-tenant-resque-and-avoiding-one-tenant-clogging-the-queue). Not all errors and jobs are created equal depending on the specific tenant being processed. Treating all errors and users as equal can cause a single tenant to clog the queue and take down the performance of the entire system.  

@jzaleski and @lantins I'd love to hear what you think of these changes!

Here's what is left to do here:

- [x] docs
- [x] test for `retry_queue`
- [x] test for passing args into `retry_delay`