### PR TITLE
Don't validate ignored exceptions

### DIFF
--- a/lib/resque/plugins/retry.rb
+++ b/lib/resque/plugins/retry.rb
@@ -54,22 +54,9 @@ module Resque
       def self.extended(receiver)
         retry_exceptions = receiver.instance_variable_get('@retry_exceptions')
         fatal_exceptions = receiver.instance_variable_get('@fatal_exceptions')
-        ignore_exceptions = receiver.instance_variable_get('@ignore_exceptions')
 
         if fatal_exceptions && retry_exceptions
           raise AmbiguousRetryStrategyException.new(%{You can't define both "@fatal_exceptions" and "@retry_exceptions"})
-        end
-
-        # Check that ignore_exceptions is a subset of retry_exceptions
-        if retry_exceptions.is_a?(Hash)
-          exceptions = retry_exceptions.keys
-        else
-          exceptions = Array(retry_exceptions)
-        end
-
-        excess_exceptions = Array(ignore_exceptions) - exceptions
-        unless excess_exceptions.empty?
-          raise RetryConfigurationException, "The following exceptions are defined in @ignore_exceptions but not in @retry_exceptions: #{excess_exceptions.join(', ')}."
         end
       end
 

--- a/test/ignore_exceptions_test.rb
+++ b/test/ignore_exceptions_test.rb
@@ -23,16 +23,4 @@ class IgnoreExceptionsTest < Minitest::Test
     perform_next_job(@worker)
     assert_equal '1', Resque.redis.get(retry_key), 'retry counter'
   end
-
-  def test_ignore_exception_configuration_1
-    assert_raises Resque::Plugins::Retry::RetryConfigurationException do
-      IgnoreExceptionsImproperlyConfiguredJob1.extend(Resque::Plugins::Retry)
-    end
-  end
-
-  def test_ignore_exception_configuration_2
-    assert_raises Resque::Plugins::Retry::RetryConfigurationException do
-      IgnoreExceptionsImproperlyConfiguredJob2.extend(Resque::Plugins::Retry)
-    end
-  end
 end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -591,16 +591,3 @@ class IgnoreExceptionsJob
     "Hello, World!"
   end
 end
-
-class IgnoreExceptionsImproperlyConfiguredJob1
-  # Manually extend Resque::Plugins::Retry in the test code to catch the
-  # exception.
-  @ignore_exceptions = [CustomException]
-end
-
-class IgnoreExceptionsImproperlyConfiguredJob2
-  # Manually extend Resque::Plugins::Retry in the test code to catch the
-  # exception.
-  @ignore_exceptions = [CustomException]
-  @retry_exceptions = { AnotherCustomException => 0 }
-end


### PR DESCRIPTION
Ignored and fatal exceptions are different functions. Fatal exceptions cause
the job to not run through the rest of the retry logic at all. Ignored exceptions
cause the job retry counter to not be increased.

Setting `@fatal_exceptions` cause custom criteria callbacks to be skipped.
This makes it impossible to ignore exceptions and implement custom retry criteria.