### PR TITLE
Loosen version requirement to allow resque v2.0 and up.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 resque-retry
 ============
 
-A [Resque][resque] plugin. Requires Resque ~> 1.25 & [resque-scheduler][resque-scheduler] ~> 4.0.
+A [Resque][resque] plugin. Requires Resque ~> 1.25 or Resque ~> 2.0 & [resque-scheduler][resque-scheduler] ~> 4.0.
 
 This gem provides retry, delay and exponential backoff support for resque jobs.
 

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($/)
   s.require_paths = %w[lib]
 
-  s.add_dependency('resque', '~> 1.25')
+  s.add_dependency('resque', '>= 1.25', '< 3.0')
   s.add_dependency('resque-scheduler', '~> 4.0')
 
   s.add_development_dependency('rake', '~> 10.3')

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -4,8 +4,13 @@ require 'test_helper'
 class ResqueTest < Minitest::Test
   def test_resque_version
     major, minor, patch = Resque::Version.split('.')
-    assert_equal 2, major.to_i, 'major version does not match'
-    assert_operator minor.to_i, :>=, 0, 'minor version is too low'
+    assert major.to_i == 1 || major.to_i == 2, 'major version does not match'
+
+    if major.to_i == 1
+      assert_operator minor.to_i, :>=, 8, 'minor version is too low'
+    else
+      assert_operator minor.to_i, :>=, 0, 'minor version is too low'
+    end
   end
 
   def test_good_job

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -4,8 +4,8 @@ require 'test_helper'
 class ResqueTest < Minitest::Test
   def test_resque_version
     major, minor, patch = Resque::Version.split('.')
-    assert_equal 1, major.to_i, 'major version does not match'
-    assert_operator minor.to_i, :>=, 8, 'minor version is too low'
+    assert_equal 2, major.to_i, 'major version does not match'
+    assert_operator minor.to_i, :>=, 0, 'minor version is too low'
   end
 
   def test_good_job


### PR DESCRIPTION
Support Resque 2.0. Closes #154.