### PR TITLE
Add test for Issue 158

### DIFF
--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -287,6 +287,12 @@ class RetryTest < Minitest::Test
     perform_next_job(@worker)
   end
 
+  def test_expire_key_set_with_retry_exceptions
+    Resque.redis.expects(:expire).once.with(PerExceptionClassRetryCountJob.redis_retry_key(StandardError), 17)
+    Resque.enqueue(PerExceptionClassRetryCountJob, StandardError)
+    perform_next_job(@worker)
+  end
+
   def test_expire_key_setting_on_the_fly
     retry_key = 'resque-retry:FailFiveTimesWithCustomExpiryJob'
 

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -546,6 +546,7 @@ class PerExceptionClassRetryCountJob
 
   @queue = :testing
   @retry_limit = 3
+  @expire_retry_key_after = 10
   @retry_exceptions = { StandardError => 7, AnotherCustomException => 11, HierarchyCustomException => 13 }
 
   def self.perform


### PR DESCRIPTION
Add test for Issue 158 (https://github.com/lantins/resque-retry/issues/158#event-2471655264)

Configuration:
```
@expire_retry_key_after = 10
@retry_exceptions = { StandardError => 7, .. }
```

should set `Resque.redis.expire` eq to `17`
