### PR TITLE
Fix Issue #160 - update method signature for ExponentialBackoff.retry_delay

### DIFF
--- a/lib/resque/plugins/exponential_backoff.rb
+++ b/lib/resque/plugins/exponential_backoff.rb
@@ -80,10 +80,11 @@ module Resque
 
       # Selects the delay from the backoff strategy
       #
+      # @param _ [Exception] unused exception argument for signature parity
       # @return [Number] seconds to delay until the next retry.
       #
       # @api private
-      def retry_delay(_exception_class = nil)
+      def retry_delay(_ = nil)
         delay = backoff_strategy[retry_attempt] || backoff_strategy.last
         # if the values are the same don't bother generating a random number, if
         # the delta is zero, some platforms will raise an error

--- a/lib/resque/plugins/exponential_backoff.rb
+++ b/lib/resque/plugins/exponential_backoff.rb
@@ -83,7 +83,7 @@ module Resque
       # @return [Number] seconds to delay until the next retry.
       #
       # @api private
-      def retry_delay
+      def retry_delay(_exception_class = nil)
         delay = backoff_strategy[retry_attempt] || backoff_strategy.last
         # if the values are the same don't bother generating a random number, if
         # the delta is zero, some platforms will raise an error

--- a/test/exponential_backoff_test.rb
+++ b/test/exponential_backoff_test.rb
@@ -128,4 +128,11 @@ class ExponentialBackoffTest < Minitest::Test
     assert_equal 4, Resque.info[:failed],     'failed jobs'
     assert_equal 0, Resque.info[:pending],    'pending jobs'
   end
+
+  def test_backoff_with_expiration
+    Resque.redis.expects(:expire)
+
+    Resque.enqueue(ExponentialBackoffWithExpiryJob)
+    perform_next_job(@worker)
+  end
 end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -254,6 +254,12 @@ class ExponentialBackoffWithRetryDelayMultiplicandMinAndMaxJob < RetryDefaultsJo
   @retry_delay_multiplicand_max = 3.0
 end
 
+class ExponentialBackoffWithExpiryJob < RetryDefaultsJob
+  extend Resque::Plugins::ExponentialBackoff
+  @queue = :testing
+  @expire_retry_key_after = 60 * 60
+end
+
 class InvalidRetryDelayMaxConfigurationJob
   @queue = :testing
   @retry_delay_multiplicand_max = 0.9


### PR DESCRIPTION
Fixes issue #160 . First commit adds a failing spec, and second commit causes it to pass.

This was the least invasive fix -- simply updating the method signature of `Resque::Plugins::ExponentialBackoff.retry_delay` to match `Resque::Plugins::Retry.retry_delay` -- but there were other options as well,

Specifically, there's already some logic to check the arity of retry_delay that could be reused or generalized, but I'm not familiar enough with the inner workings and uses of this library to be comfortable with that change. Aforementioned logic here: https://github.com/goatapp/resque-retry/blob/cf0070eee3dce064e4a83e1dc01943260bab1ac2/lib/resque/plugins/retry.rb#L390-L390