### PR TITLE
Add missing quote to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ class ExampleJob
     user_id, user_mode, record_id = *args
 
     if user_mode
-      'high
+      'high'
     else
       'low'
     end


### PR DESCRIPTION
An example's syntax highlighting was odd due to a missing quote.