### PR TITLE
Clarify the argument in retry_delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ class ExampleJob
   extend Resque::Plugins::Retry
   @queue = :testing
 
-  def self.retry_delay(exception)
-    if exception == SocketError
+  def self.retry_delay(exception_class)
+    if exception_class == SocketError
       10
     else
       1


### PR DESCRIPTION
Based on the try_again code and my own testing, it is the class and not the
exception that is passed, as the example's comparison already implies --
the naming just wasn't consistent.