### PR TITLE
Fix Redis 4.3 breaking saving job failures with multiple failure backend

### DIFF
--- a/test/multiple_failure_test.rb
+++ b/test/multiple_failure_test.rb
@@ -157,6 +157,20 @@ class MultipleFailureTest < Minitest::Test
     end
   end
 
+  def test_redis_exists_returns_integer
+    Resque.enqueue(RetryDefaultsJob)
+    original = Redis.exists_returns_integer
+    Redis.exists_returns_integer = true
+
+    3.times do
+      perform_next_job(@worker)
+    end
+
+    Redis.exists_returns_integer = original
+
+    assert_equal 1, MockFailureBackend.errors.size
+  end
+
   def teardown
     Resque::Failure.backend = @old_failure_backend
   end


### PR DESCRIPTION
[redis](https://github.com/redis/redis-rb) is changing their behavior in 4.3 such that `Redis.exists` will return an integer instead of a boolean. This behavior change causes a bug in the multiple failure with suppression failure backend resulting in failed jobs not being saved.

Currently, calling `retrying?` from the multiple with retry suppression backend logs this warning (resque-retry is on redis 4.2.5):

```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. 
```

The problem is `lib/resque/failure/multiple_with_retry_suppression.rb` lines 34-37 and 135:

```
retryable = retryable? # line 34
job_being_retried = retryable && retrying?

if !job_being_retried

# ...

def retrying?
  Resque.redis.exists(retry_key) # line 135
end
```

If `retrying?` returns 0, then `if !job_being_retried` evaluates  `!0` which is `false`. Setting `Redis.exists_returns_integer` results in resque-retry not reporting failed jobs. This becomes complicated because some gems, such as [mock redis](https://github.com/sds/mock_redis) do not have such a config option and simply use the new behavior, resulting in unexpected behavior from resque-retry.

This pull request fixes the bug by using `Redis.exists?` in favor of `Redis.exists`. 