### PR TITLE
Add resque-scheduler 5 support

### DIFF
--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency('resque', '>= 1.25', '< 3.0')
-  s.add_dependency('resque-scheduler', '~> 4.0')
+  s.add_dependency('resque-scheduler', '>= 4.0', '<6.0')
 
   s.add_development_dependency('rake', '~> 10.3')
   s.add_development_dependency('minitest', '~> 5.5')


### PR DESCRIPTION
Hello,

`resque-retry` depends on `resque-scheduler` version `~> 4.0` but it's master branch (which contains useful fixes like [this](https://github.com/resque/resque-scheduler/commit/f6603dc813cda86cc28b4eab08b69c524fdc0781)) already bumped version `5`.

This PR enables using master's branch of `resque-scheduler` with `resque-retry`.

I've tested this PR locally adding `gem 'resque-scheduler', github: 'resque/resque-scheduler'` to the Gemfile and everything is green (I don't know how to include this test on the testsuite, please suggests me).

Thanks,
Andrea