### PR TITLE
fall back to old key check on error

### DIFF
--- a/lib/resque/failure/multiple_with_retry_suppression.rb
+++ b/lib/resque/failure/multiple_with_retry_suppression.rb
@@ -150,7 +150,11 @@ module Resque
 
       def redis_key_exists?(key)
         if Resque.redis.respond_to?(:exists?)
-          Resque.redis.exists?(key)
+          begin
+            Resque.redis.exists?(key)
+          rescue
+            ![false, 0].include?(Resque.redis.exists(key) || false)
+          end
         else
           ![false, 0].include?(Resque.redis.exists(key) || false)
         end


### PR DESCRIPTION
We have encountered an issue where failed jobs will not be moved into the failed queue after exhausting all retry attempts. We noticed this change in behavior when updating from `redis-namespace` `1.5.2 => 1.8.2`, and have tracked this behavior down to this key check in the `MultipleWithRetrySuppression` backend. 

We are using redis-rb 3.3.5, so the newer version of redis-namespace defines the method `exists?` (and a bunch of other pass through methods), but it will fail when trying to execute. What then happens is that the failing job retries as defined with `resque-retry`, but then it will get dropped without being moved to the failed queue. 

This update is what gets it to work for us. I wanted to have it `rescue Redis::CommandError`, but that didn't seem to handle it properly. 

This is somewhat similar to an [issue on the `redis-namespace` repo](https://github.com/resque/redis-namespace/issues/172) and also to an [older issue on `sidekiq-scheduler`](https://github.com/sidekiq-scheduler/sidekiq-scheduler/issues/345)

Our full gem set around Redis/Resque is as follows, with the commented line being the working version of `redis-namespace`

```ruby
gem 'redis', '3.3.5'
gem 'redis-namespace', '1.8.2'
# gem 'redis-namespace', '1.5.2'
gem 'redis-store', '1.4.1'
gem 'resque', '1.26.0'
gem 'resque-cleaner', '0.3.0'
gem "resque-dynamic-queues", "0.8.1"
gem 'resque-loner', '1.3.0'
gem 'resque_mailer', '2.4.3'
gem 'resque-queue-priority', '0.6.2'
gem 'resque-restriction', '0.7.0'
gem 'resque-retry', '1.7.6'
gem 'resque-scheduler', '4.3.0'
```