### PR TITLE
Address growing pains related to dependency interface changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        ruby-version: ['3.0', '2.7', '2.6']
+        ruby-version: ['3.1', '3.0', '2.7']
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/resque/failure/multiple_with_retry_suppression.rb
+++ b/lib/resque/failure/multiple_with_retry_suppression.rb
@@ -149,11 +149,7 @@ module Resque
       private
 
       def redis_key_exists?(key)
-        if Resque.redis.respond_to?(:exists?)
-          Resque.redis.exists?(key)
-        else
-          ![false, 0].include?(Resque.redis.exists(key) || false)
-        end
+        ![false, 0].include?(Resque.redis.exists(key) || false)
       end
     end
   end

--- a/test/multiple_failure_test.rb
+++ b/test/multiple_failure_test.rb
@@ -91,7 +91,7 @@ class MultipleFailureTest < Minitest::Test
 
     Resque.enqueue(LimitThreeJobDelay1Hour)
     perform_next_job(@worker)
-    assert !Resque.redis.exists(key), 'key should have been removed.'
+    assert [false, 0].include?(Resque.redis.exists(key) || false), 'key should have been removed.'
   end
 
   def test_last_failure_has_double_delay_redis_expiry_if_delay
@@ -109,7 +109,7 @@ class MultipleFailureTest < Minitest::Test
 
     # I don't like this, but...
     key = failure_key_for(LimitThreeJob)
-    assert !Resque.redis.exists(key)
+    assert [false, 0].include?(Resque.redis.exists(key) || false), 'key should have not been added.'
   end
 
   def test_errors_are_suppressed_up_to_retry_limit
@@ -158,7 +158,10 @@ class MultipleFailureTest < Minitest::Test
   end
 
   def test_redis_exists_returns_integer
+    return if !Redis.respond_to?(:exists_returns_integer)
+
     Resque.enqueue(RetryDefaultsJob)
+
     original = Redis.exists_returns_integer
     Redis.exists_returns_integer = true
 

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ResqueTest < Minitest::Test
   def test_resque_version
-    major, minor, _ = Resque::Version.split('.')
+    major, minor, _ = resque_version.split('.')
     assert [1, 2].include?(major.to_i), 'major version does not match'
 
     if major.to_i == 1
@@ -18,5 +18,15 @@ class ResqueTest < Minitest::Test
     assert_equal 0, Resque.info[:failed], 'failed jobs'
     assert_equal 1, Resque.info[:processed], 'processed job'
     assert_equal 0, Resque.delayed_queue_schedule_size
+  end
+
+  private
+
+  def resque_version
+    begin
+      Resque::VERSION
+    rescue NameError
+      Resque::Version
+    end
   end
 end

--- a/test/retry_test.rb
+++ b/test/retry_test.rb
@@ -316,7 +316,7 @@ class RetryTest < Minitest::Test
       2.times do
         job = @worker.reserve
         child = fork do
-          Resque.redis.client.reconnect
+          Resque.redis.reconnect rescue Resque.redis.client.reconnect
           job.perform
         end
         Process.waitpid(child)


### PR DESCRIPTION
* Address `retry_key_exists?` issue that was originally reported / partially addressed here: https://github.com/lantins/resque-retry/pull/173
* Fix test-failures due to API / interface changes for dependencies
* Remove `ruby@2.6` from the test[ing] matrix as it has been EOL for quite some time at this point (as of this PR `ruby@2.7` is also EOL, but I left this in for the time being)
* Add `ruby@3.1` to the test[ing] matrix