### PR TITLE
Prevent crashing when the retry key is nil (redis-rb >= 5)

### DIFF
--- a/lib/resque-retry/server.rb
+++ b/lib/resque-retry/server.rb
@@ -43,7 +43,7 @@ module ResqueRetry
         if klass.respond_to?(:redis_retry_key)
           klass.redis_retry_key(job['args'])
         else
-          nil
+          ''
         end
       end
 

--- a/test/server_helpers_test.rb
+++ b/test/server_helpers_test.rb
@@ -19,4 +19,15 @@ class ServerHelpersTest < Minitest::Test
     job = Resque.delayed_timestamp_peek(timestamp, 0, 1).first
     assert_equal '0', @helpers.retry_attempts_for_job(job), 'should have 0 retry attempt'
   end
+
+  def test_retry_key_for_job_empty
+    Resque.enqueue(DelayedJobNoRetryKey)
+    perform_next_job(@worker)
+
+    timestamp = Resque.delayed_queue_peek(0, 1).first
+    job = Resque.delayed_timestamp_peek(timestamp, 0, 1).first
+
+    assert_equal '', @helpers.retry_key_for_job(job), 'should be empty string otherwise will break with redis 5'
+    assert_nil @helpers.retry_attempts_for_job(job), 'should have nil retry attempts as the key does not exist'
+  end
 end

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -198,6 +198,10 @@ class LimitThreeJobDelay1Hour < LimitThreeJob
   @retry_delay = 3600
 end
 
+class DelayedJobNoRetryKey
+  @queue = :testing
+end
+
 class FailFiveTimesJob < RetryDefaultsJob
   @queue = :testing
   @retry_limit = 6


### PR DESCRIPTION
### TL;DR; 
When using redis-rb >=5, `resque-retry` crashes if the retry key for a job is `nil` since the `redis.get(key)` method does not support nil keys anymore. The fix is simply returning an empty string instead of `nil`.

---

### Long version

Delayed jobs that don't extend the `resque-retry` plugin don't have the `redis_retry_key` [method](https://github.com/lantins/resque-retry/blob/223897a7f920469543d96f3f335486d6d85e5036/lib/resque/plugins/retry.rb#L101) implemented, so the server will return `nil` when calling the `retry_key_for_job` [method](https://github.com/lantins/resque-retry/blob/223897a7f920469543d96f3f335486d6d85e5036/lib/resque-retry/server.rb#L41).

With redis-rb >=5, when we call `Resque.redis.get(value)` with the value being `nil`, it raises `TypeError: Unsupported command argument type: NilClass`, breaking the retry page on resque web.

The fix is very simple as we just need to return an empty string when the job does not have the retry key.