### PR TITLE
Add newest Ruby versions to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.1', '3.0', '2.7']
+        ruby-version: ['3.3', '3.2', '3.1', '3.0', '2.7']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 3.2 and 3.3 to the CI matrix.