### PR TITLE
Fix CI failing and update it with newer Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.1', '3.0', '2.7']
+        ruby-version: ['3.3', '3.2', '3.1', '3.0', '2.7']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
           - 6379:6379
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.0', '2.7']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7']
 
     steps:
       - uses: actions/checkout@v2

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency('resque', '>= 1.25', '< 3.0')
   s.add_dependency('resque-scheduler', '>= 4.0', '<6.0')
 
-  s.add_development_dependency('rake', '~> 10.3')
+  s.add_development_dependency('rake', '>= 10.3', '< 14')
   s.add_development_dependency('minitest', '~> 5.5')
   s.add_development_dependency('rack-test', '~> 0.6')
   s.add_development_dependency('yard', '~> 0.8')

--- a/resque-retry.gemspec
+++ b/resque-retry.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard', '~> 0.8')
   s.add_development_dependency('json', '~> 2.0')
   s.add_development_dependency('simplecov', '~> 0.9')
-  s.add_development_dependency('mocha', '~> 1.1')
+  s.add_development_dependency('mocha', '~> 2.1')
 end

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -4,7 +4,7 @@ require 'resque-retry/server'
 ENV['RACK_ENV'] = ENV['RAILS_ENV']
 
 # Testing the Resque web interface additions.
-class ServerTest < MiniTest::Test
+class ServerTest < Minitest::Test
   include Rack::Test::Methods
 
   def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ require 'timeout'
 require 'minitest/autorun'
 require 'minitest/pride'
 require 'rack/test'
-require 'mocha/setup'
+require 'mocha/minitest'
 
 require 'resque-retry'
 require dir + '/test_jobs'


### PR DESCRIPTION
This PR fixes the CI that is currently failing and adds Ruby 3.2 and 3.3 to the CI matrix.